### PR TITLE
feat(provider): add DeepSeek FIM provider

### DIFF
--- a/provider/deepseek.go
+++ b/provider/deepseek.go
@@ -1,0 +1,163 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	"llm-language-server/cache"
+	"llm-language-server/lsp"
+)
+
+type DeepSeekModelParams struct {
+	LogProbs    *uint
+	MaxTokens   *uint
+	Temperature *float64
+	TopP        *float64
+	Stop        *[]string
+}
+
+type DeepSeekProvider struct {
+	Model       string
+	ApiKey      string
+	ModelParams DeepSeekModelParams
+}
+
+type DeepSeekModelDetails struct {
+	LogProbs    *uint     `json:"logprobs"`
+	MaxTokens   *uint     `json:"max_tokens"`
+	Temperature *float64  `json:"temperature"`
+	TopP        *float64  `json:"top_p"`
+	Stop        *[]string `json:"stop"`
+}
+
+type DeepSeekInitializationParams struct {
+	Model       string               `json:"model"`
+	ApiKey      string               `json:"api_key"`
+	ModelParams DeepSeekModelDetails `json:"model_params"`
+}
+
+type DeepSeekChoice struct {
+	Index int    `json:"index"`
+	Text  string `json:"text"`
+}
+
+type DeepSeekResponse struct {
+	Choices []DeepSeekChoice `json:"choices"`
+}
+
+func (p *DeepSeekProvider) Initialize(params any) error {
+	jsonParams, err := json.Marshal(params)
+	if err != nil {
+		return err
+	}
+	var deepSeekParams DeepSeekInitializationParams
+	err = json.Unmarshal(jsonParams, &deepSeekParams)
+	if err != nil {
+		return err
+	}
+
+	p.Model = deepSeekParams.Model
+	p.ApiKey = deepSeekParams.ApiKey
+	p.ModelParams.LogProbs = deepSeekParams.ModelParams.LogProbs
+	p.ModelParams.MaxTokens = deepSeekParams.ModelParams.MaxTokens
+	p.ModelParams.Temperature = deepSeekParams.ModelParams.Temperature
+	p.ModelParams.TopP = deepSeekParams.ModelParams.TopP
+	p.ModelParams.Stop = deepSeekParams.ModelParams.Stop
+
+	return nil
+}
+
+func (p *DeepSeekProvider) Generate(
+	ctx context.Context,
+	params lsp.InlineCompletionParams,
+) ([]lsp.CompletionItem, error) {
+	items := make([]lsp.CompletionItem, 0)
+
+	if p.ApiKey == "" {
+		return items, fmt.Errorf("api key not set")
+	}
+
+	document, exists := lsp.State[string(params.TextDocument.Uri)]
+	if !exists {
+		return items, fmt.Errorf("document not found %s", params.TextDocument.Uri)
+	}
+
+	index := lsp.FindIndex(document.Text, params.Position.Line, params.Position.Character)
+	// DeepSeek FIM formatting is limited to a context window of 4k tokens for now
+	prompt, suffix := truncate(document.Text, index, 4000)
+
+	cacheValue, exists := cache.Get(prompt, suffix)
+	if exists {
+		return cacheValue, nil
+	}
+
+	data := map[string]any{
+		"model":       p.Model,
+		"prompt":      prompt,
+		"suffix":      suffix,
+		"logprobs":    p.ModelParams.LogProbs,
+		"max_tokens":  p.ModelParams.MaxTokens,
+		"temperature": p.ModelParams.Temperature,
+		"top_p":       p.ModelParams.TopP,
+		"stop":        p.ModelParams.Stop,
+	}
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return items, err
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		"POST",
+		"https://api.deepseek.com/beta/completions",
+		bytes.NewBuffer(jsonData),
+	)
+	if err != nil {
+		return items, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+p.ApiKey)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		if err == context.Canceled {
+			return items, nil
+		}
+		return items, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return items, err
+	}
+
+	var response DeepSeekResponse
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return items, err
+	}
+
+	for _, choice := range response.Choices {
+		items = append(
+			items,
+			lsp.CompletionItem{
+				Label:      strconv.Itoa(choice.Index),
+				InsertText: choice.Text,
+			},
+		)
+	}
+
+	cache.Set(prompt, suffix, items)
+
+	return items, nil
+}

--- a/provider/ollama.go
+++ b/provider/ollama.go
@@ -9,7 +9,6 @@ import (
 	"llm-language-server/cache"
 	"llm-language-server/lsp"
 	"net/http"
-	"strings"
 )
 
 type OllamaModelParams struct {
@@ -225,44 +224,6 @@ type OllamaGenerateResponse struct {
 	CreatedAt string `json:"created_at"`
 	Response  string `json:"response"`
 	Done      bool   `json:"done"`
-}
-
-func truncate(text string, index int, ctx int) (string, string) {
-	promptLines := strings.Split(text[:index], "\n")
-	suffixLines := strings.Split(text[index:], "\n")
-
-	prompt := promptLines[len(promptLines)-1]
-	suffix := suffixLines[len(suffixLines)-1]
-
-	ctxSize := len(prompt+suffix) / 4
-
-	promptLinesCount := 1
-	suffixLinesCount := 1
-
-	ctxInc := true
-	for ctxInc {
-		ctxInc = false
-
-		if suffixLinesCount < len(suffixLines) {
-			suffix_line := suffixLines[suffixLinesCount]
-			if ctxSize+len(suffix_line) < ctx {
-				suffix = suffix + "\n" + suffix_line
-				suffixLinesCount++
-				ctxInc = true
-			}
-		}
-
-		if promptLinesCount < len(promptLines) {
-			promptLine := promptLines[len(promptLines)-promptLinesCount-1]
-			if ctxSize+len(promptLine) < ctx {
-				prompt = promptLine + "\n" + prompt
-				promptLinesCount++
-				ctxInc = true
-			}
-		}
-	}
-
-	return prompt, suffix
 }
 
 func (p *OllamaProvider) Generate(ctx context.Context, params lsp.InlineCompletionParams) ([]lsp.CompletionItem, error) {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	"llm-language-server/lsp"
 )
 
@@ -26,6 +27,9 @@ func Initialize(options lsp.InitializationOptions, params any) error {
 		return CurrentProvider.Initialize(params)
 	case "ollama":
 		CurrentProvider = &OllamaProvider{}
+		return CurrentProvider.Initialize(params)
+	case "deepseek":
+		CurrentProvider = &DeepSeekProvider{}
 		return CurrentProvider.Initialize(params)
 	}
 

--- a/provider/util.go
+++ b/provider/util.go
@@ -1,0 +1,47 @@
+package provider
+
+import "strings"
+
+// truncate extracts a window of lines around position `index` in `text`.
+// Returns (promptBeforeCursor, suffixAfterCursor) expanded outward line by
+// line up to `ctx` total characters.
+func truncate(text string, index int, ctx int) (string, string) {
+	promptLines := strings.Split(text[:index], "\n")
+	suffixLines := strings.Split(text[index:], "\n")
+
+	// Start with current line on each side
+	prompt := promptLines[len(promptLines)-1]
+	suffix := suffixLines[len(suffixLines)-1]
+
+	// Rough estimate of characters so far (quarter of actual to bias expansion)
+	ctxSize := len(prompt+suffix) / 4
+
+	promptLinesCount := 1
+	suffixLinesCount := 1
+
+	// Alternating expansion: suffix line, then prompt line, repeat
+	ctxInc := true
+	for ctxInc {
+		ctxInc = false
+
+		if suffixLinesCount < len(suffixLines) {
+			suffix_line := suffixLines[suffixLinesCount]
+			if ctxSize+len(suffix_line) < ctx {
+				suffix = suffix + "\n" + suffix_line
+				suffixLinesCount++
+				ctxInc = true
+			}
+		}
+
+		if promptLinesCount < len(promptLines) {
+			promptLine := promptLines[len(promptLines)-promptLinesCount-1]
+			if ctxSize+len(promptLine) < ctx {
+				prompt = promptLine + "\n" + prompt
+				promptLinesCount++
+				ctxInc = true
+			}
+		}
+	}
+
+	return prompt, suffix
+}


### PR DESCRIPTION
Register DeepSeek as a new LLM provider option alongside existing Codestral and Ollama providers.

- Implement DeepSeekProvider with Initialize and Generate methods
- Support optional model params: logprobs, max_tokens, temperature, top_p, stop sequences
- Use DeepSeek beta completions endpoint for inline completion
- Cache results via shared cache layer for repeated prompts